### PR TITLE
Request keyboard mapping instead of hardcoding

### DIFF
--- a/airwm.js
+++ b/airwm.js
@@ -103,7 +103,7 @@ x11.createClient(function(err, display) {
 			var binding =  key_combinations[binding_index];
 			// Check if this is the binding which we are seeking.
 			if(binding.key === ev.keycode){
-				if(translateModifiers(binding.modifier) === ev.buttons){
+				if(translateModifiers(binding.modifier) === (ev.buttons&translateModifiers(binding.modifier))){
 					if(binding.hasOwnProperty('command')){
 						console.log("Launching airwm-command: '", binding.command, "'.");
 						if(binding.command === "Shutdown"){


### PR DESCRIPTION
When translateModifiers() returns 64, it does not work for me, as it should return 80 on my system. Therefore, we should make translateModifiers() return the correct number.
