### PR TITLE
Application crashes when log file is not present

### DIFF
--- a/lib/airwm.js
+++ b/lib/airwm.js
@@ -1,8 +1,9 @@
+var fs		= require("fs");
 var x11     = require('x11');
 var exec    = require('child_process').exec;
 var keysym  = require('keysym');
 var conversion = require('./conversion');
-var logger = require('./logger').logger;
+var logger  = require('./logger').logger;
 
 // Load the objects from objects.js
 var Workspaces = require('./objects/workspaces').Workspaces,
@@ -174,7 +175,14 @@ var eventHandler = function(ev){
 	}
 }
 
+//creates the logDir directory when it doesn't exist (otherwise Winston fails)
+var initLogger = function (logDir){
+	if(!fs.existsSync(logDir))
+		fs.mkdirSync(logDir);
+}
+
 var airClientCreator = function(err, display) {
+	initLogger('logs');
 	logger.info("Initializing AirWM client.");
 	// Set the connection to the X server in global namespace
 	// as a hack since almost every file uses it


### PR DESCRIPTION
The error:

```
2015-01-06T15:04:04.433Z - info: Initializing AirWM client.

events.js:48
        throw arguments[1]; // Unhandled 'error' event
                       ^
Error: ENOENT, no such file or directory 'logs/airwm.log'
```