### PR TITLE
Implemented auto-close all windows on exit.

### DIFF
--- a/lib/airwm.js
+++ b/lib/airwm.js
@@ -83,10 +83,19 @@ var closeWindowHandler = function(close_id) {
 	});
 }
 
+var closeAllWindows = function(close_id) {
+	logger.info("Closing all windows.");
+	var screens = workspaces.getCurrentWorkspace().screens;
+	for(var i in screens){
+		screens[i].closeAllWindows();
+	}
+}
+
 var commandHandler = function(command) {
 	logger.info("Launching airwm-command: '%s'.", command);
 	switch(command){
 		case "Shutdown":
+			closeAllWindows();
 			process.exit(0);
 			break;
 		case "CloseWindow":

--- a/lib/objects/screen.js
+++ b/lib/objects/screen.js
@@ -30,6 +30,16 @@ function Screen(screen, parent) {
 		this.window_tree.switchTilingMode();
 	}
 
+	this.closeAllWindows = function(){
+		var windows = this.window_tree.children;
+		if(windows==null){
+			return;
+		}
+		while(windows.length!=0){
+			windows[0].destroy();
+		}
+	}
+
 	this.forEachWindow = function(callback) {
 		this.window_tree.forEachWindow(callback);
 	}


### PR DESCRIPTION
Implemented the ability to automatically close all the windows on
termination of AirWM. A method was added for the screen object to close
all the windows on a certain screen. In the main file it the
functionality was added by going through all the screens and calling the
new method.

Signed-off-by: Martin Jorn Rogalla <martin@martinrogalla.com>