### PR TITLE
Keybindings don't work anymore after closing all windows.

### DIFF
--- a/lib/airwm.js
+++ b/lib/airwm.js
@@ -192,6 +192,15 @@ var destroyNotifyHandler = function(ev){
 }
 
 var mapRequestHandler = function(ev){
+	global.X.GetWindowAttributes(ev.wid, function(err, attributes) {
+		// Don't manage a window when a redirect-override flag is set.
+		// (don't create windows for small popups e.g. firefox search history)
+		if (attributes[8])
+		{
+			global.X.MapWindow(ev.wid);
+			return;
+		}
+	});
 	global.X.ChangeWindowAttributes(
 		ev.wid,
 		{ eventMask: x11.eventMask.EnterWindow }

--- a/lib/airwm.js
+++ b/lib/airwm.js
@@ -210,7 +210,9 @@ var eventHandler = function(ev){
 	logger.debug("Received a %s event.", ev.name);
 	switch( ev.name ) {
 	case "ConfigureRequest":
-		// Do nothing, we decide the location and size of the window.
+		// Allow requested resize for optimization. Window gets resized
+		// automatically by AirWM again anyway.
+		X.ResizeWindow(ev.wid, ev.width, ev.height);
 		break
 	case "MapRequest":
 		mapRequestHandler(ev);

--- a/lib/airwm.js
+++ b/lib/airwm.js
@@ -82,6 +82,11 @@ var commandHandler = function(command) {
 					w = window;
 				});
 				if( w !== null ) w.focus();
+				
+				// when all windows have been closed, set the focus to the root window
+				if(workspaces.getCurrentWorkspace().screens[0].window_tree.children.length === 0){
+					global.X.SetInputFocus(workspaces.getCurrentWorkspace().screens[0].root_window_id);
+				}
 			}
 			break;
 		case "SwitchTilingMode":

--- a/lib/airwm.js
+++ b/lib/airwm.js
@@ -67,6 +67,16 @@ var closeAllWindows = function(close_id) {
 	}
 }
 
+
+// when all windows have been closed, set the focus to the root window
+var setFocusToRootIfNecessary = function(){
+	var screen = workspaces.getCurrentWorkspace().screens[0];
+	if(screen.window_tree.children.length === 0){
+		logger.info("Setting focus to the root window");
+		global.X.SetInputFocus(screen.root_window_id);
+	}
+}
+
 var commandHandler = function(command) {
 	logger.info("Launching airwm-command: '%s'.", command);
 	switch(command){
@@ -83,10 +93,7 @@ var commandHandler = function(command) {
 				});
 				if( w !== null ) w.focus();
 				
-				// when all windows have been closed, set the focus to the root window
-				if(workspaces.getCurrentWorkspace().screens[0].window_tree.children.length === 0){
-					global.X.SetInputFocus(workspaces.getCurrentWorkspace().screens[0].root_window_id);
-				}
+				setFocusToRootIfNecessary();
 			}
 			break;
 		case "SwitchTilingMode":
@@ -181,6 +188,7 @@ var destroyNotifyHandler = function(ev){
 			}
 		}
 	});
+	setFocusToRootIfNecessary();
 }
 
 var mapRequestHandler = function(ev){

--- a/lib/objects/window.js
+++ b/lib/objects/window.js
@@ -207,20 +207,22 @@ function Window(window_id, parent, screen) {
 	 * kill the window process.
 	 */
 	this.remove = function() {
-		// Remove this window from the parent container
-		this.parent.children.splice(this.parent.children.indexOf(this),1);
-		// If the parent container is now empty remove it
-		if( this.parent.children.length === 0 ) {
-			this.parent.remove();
+		if(this.parent !== null){
+			// Remove this window from the parent container
+			this.parent.children.splice(this.parent.children.indexOf(this),1);
+			// If the parent container is now empty remove it
+			if( this.parent.children.length === 0 ) {
+				this.parent.remove();
+			}
+			// If the parent is now only has 1 child try to merge it upwards
+			else if( this.parent.children.length === 1 ) {
+				this.parent.merge();
+			}
+			else {
+				this.parent.redraw();
+			}
+			this.parent = null;			
 		}
-		// If the parent is now only has 1 child try to merge it upwards
-		else if( this.parent.children.length === 1 ) {
-			this.parent.merge();
-		}
-		else {
-			this.parent.redraw();
-		}
-		this.parent = null;
 	}
 
 	/**


### PR DESCRIPTION
If all windows are closed (via the close window keybinding or via the programs themself) you can't launch any keybindings anymore. Most notably is that you can't launch dmenu_run anymore.
If you start without any windows it works untill a window was added and removed.